### PR TITLE
Refactor SequentialReader to use pimpls

### DIFF
--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -40,7 +40,8 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2/serialization_format_converter_factory.cpp
   src/rosbag2/typesupport_helpers.cpp
   src/rosbag2/writer.cpp
-  src/rosbag2/types/introspection_message.cpp)
+  src/rosbag2/types/introspection_message.cpp
+  src/rosbag2/impl/sequential_reader_impl.cpp)
 
 ament_target_dependencies(${PROJECT_NAME}
   ament_index_cpp

--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -100,10 +100,8 @@ public:
   virtual std::vector<TopicMetadata> get_all_topics_and_types();
 
 private:
-  std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
-  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
-  std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_;
-  std::unique_ptr<Converter> converter_;
+  class ReaderImpl;
+  std::shared_ptr<ReaderImpl> reader_pimpl_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -1,4 +1,5 @@
 // Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +40,9 @@
 
 namespace rosbag2
 {
+
+class ReaderImpl;
+
 /**
  * The SequentialReader allows opening and reading messages of a bag. Messages will be read
  * sequentially according to timestamp.
@@ -46,8 +50,7 @@ namespace rosbag2
 class ROSBAG2_PUBLIC SequentialReader
 {
 public:
-  explicit
-  SequentialReader(
+  explicit SequentialReader(
     std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory =
     std::make_unique<rosbag2_storage::StorageFactory>(),
     std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory =
@@ -100,8 +103,7 @@ public:
   virtual std::vector<TopicMetadata> get_all_topics_and_types();
 
 private:
-  class ReaderImpl;
-  std::shared_ptr<ReaderImpl> reader_pimpl_;
+  std::unique_ptr<ReaderImpl> reader_impl_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/impl/sequential_reader_impl.cpp
+++ b/rosbag2/src/rosbag2/impl/sequential_reader_impl.cpp
@@ -1,0 +1,114 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "sequential_reader_impl.hpp"
+
+namespace rosbag2
+{
+
+ReaderImpl::ReaderImpl(
+  std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
+  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory)
+: storage_factory_(std::move(storage_factory)),
+  converter_factory_(std::move(converter_factory))
+{}
+
+
+ReaderImpl::~ReaderImpl()
+{
+  reset();
+}
+
+void ReaderImpl::reset()
+{
+  storage_.reset();
+}
+
+void ReaderImpl::open(
+  const StorageOptions & storage_options, const ConverterOptions & converter_options)
+{
+  storage_ = storage_factory_->open_read_only(storage_options.uri, storage_options.storage_id);
+  if (!storage_) {
+    throw std::runtime_error("No storage could be initialized. Abort");
+  }
+  auto topics = storage_->get_metadata().topics_with_message_count;
+  if (topics.empty()) {
+    return;
+  }
+  // Currently a bag file can only be played if all topics have the same serialization format.
+  check_topics_serialization_formats(topics);
+  check_converter_serialization_format(
+    converter_options.output_serialization_format,
+    topics[0].topic_metadata.serialization_format);
+}
+
+bool ReaderImpl::has_next()
+{
+  if (storage_) {
+    return storage_->has_next();
+  }
+  throw std::runtime_error("Bag is not open. Call open() before reading.");
+}
+
+std::shared_ptr<SerializedBagMessage> ReaderImpl::read_next()
+{
+  if (storage_) {
+    auto message = storage_->read_next();
+    return converter_ ? converter_->convert(message) : message;
+  }
+  throw std::runtime_error("Bag is not open. Call open() before reading.");
+}
+
+std::vector<TopicMetadata> ReaderImpl::get_all_topics_and_types()
+{
+  if (storage_) {
+    return storage_->get_all_topics_and_types();
+  }
+  throw std::runtime_error("Bag is not open. Call open() before reading.");
+}
+
+void ReaderImpl::check_topics_serialization_formats(const std::vector<TopicInformation> & topics)
+{
+  auto storage_serialization_format = topics[0].topic_metadata.serialization_format;
+  for (const auto & topic : topics) {
+    if (topic.topic_metadata.serialization_format != storage_serialization_format) {
+      throw std::runtime_error(
+              "Topics with different rwm serialization format have been found. "
+              "All topics must have the same serialization format.");
+    }
+  }
+}
+
+void ReaderImpl::check_converter_serialization_format(
+  const std::string & converter_serialization_format,
+  const std::string & storage_serialization_format)
+{
+  if (converter_serialization_format != storage_serialization_format) {
+    converter_ = std::make_unique<Converter>(
+      storage_serialization_format,
+      converter_serialization_format,
+      converter_factory_);
+    auto topics = storage_->get_all_topics_and_types();
+    for (const auto & topic_with_type : topics) {
+      converter_->add_topic(topic_with_type.name, topic_with_type.type);
+    }
+  }
+}
+}  // namespace rosbag2

--- a/rosbag2/src/rosbag2/impl/sequential_reader_impl.hpp
+++ b/rosbag2/src/rosbag2/impl/sequential_reader_impl.hpp
@@ -1,0 +1,140 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__IMPL__SEQUENTIAL_READER_IMPL_HPP_
+#define ROSBAG2__IMPL__SEQUENTIAL_READER_IMPL_HPP_
+
+#include "rosbag2/sequential_reader.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace rosbag2
+{
+
+class SequentialReader::ReaderImpl
+{
+public:
+  ReaderImpl(
+    std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
+    std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory)
+  : storage_factory_(std::move(storage_factory)),
+    converter_factory_(std::move(converter_factory)),
+    converter_(nullptr) {}
+
+  ~ReaderImpl()
+  {
+    storage_.reset();
+  }
+
+  void open(
+    const StorageOptions & storage_options, const ConverterOptions & converter_options)
+  {
+    storage_ = storage_factory_->open_read_only(storage_options.uri, storage_options.storage_id);
+    if (!storage_) {
+      throw std::runtime_error("No storage could be initialized. Abort");
+    }
+    auto topics = storage_->get_metadata().topics_with_message_count;
+    if (topics.empty()) {
+      return;
+    }
+
+    // Currently a bag file can only be played if all topics have the same serialization format.
+    check_topics_serialization_formats(topics);
+    check_converter_serialization_format(
+      converter_options.output_serialization_format,
+      topics[0].topic_metadata.serialization_format);
+  }
+
+  bool has_next()
+  {
+    if (storage_) {
+      return storage_->has_next();
+    }
+    throw std::runtime_error("Bag is not open. Call open() before reading.");
+  }
+
+  std::shared_ptr<SerializedBagMessage> read_next()
+  {
+    if (storage_) {
+      auto message = storage_->read_next();
+      return converter_ ? converter_->convert(message) : message;
+    }
+    throw std::runtime_error("Bag is not open. Call open() before reading.");
+  }
+
+  std::vector<TopicMetadata> get_all_topics_and_types()
+  {
+    if (storage_) {
+      return storage_->get_all_topics_and_types();
+    }
+    throw std::runtime_error("Bag is not open. Call open() before reading.");
+  }
+
+private:
+  /**
+   * Checks if all topics in the bagfile have the same RMW serialization format.
+   * Currently a bag file can only be played if all topics have the same serialization format.
+   *
+   * \param topics Vector of TopicInformation with metadata.
+   * \throws runtime_error if any topic has a different serialization format from the rest.
+   */
+  virtual void check_topics_serialization_formats(const std::vector<TopicInformation> & topics)
+  {
+    auto storage_serialization_format = topics[0].topic_metadata.serialization_format;
+    for (const auto & topic : topics) {
+      if (topic.topic_metadata.serialization_format != storage_serialization_format) {
+        throw std::runtime_error(
+                "Topics with different rwm serialization format have been found. "
+                "All topics must have the same serialization format.");
+      }
+    }
+  }
+
+  /**
+   * Checks if the serialization format of the converter factory is the same as that of the storage
+   * factory.
+   * If not, changes the serialization format of the converter factory to use the serialization
+   * format of the storage factory.
+   *
+   * \param converter_serialization_format
+   * \param storage_serialization_format
+   */
+  virtual void check_converter_serialization_format(
+    const std::string & converter_serialization_format,
+    const std::string & storage_serialization_format)
+  {
+    if (converter_serialization_format != storage_serialization_format) {
+      converter_ = std::make_unique<Converter>(
+        storage_serialization_format,
+        converter_serialization_format,
+        converter_factory_);
+      auto topics = storage_->get_all_topics_and_types();
+      for (const auto & topic_with_type : topics) {
+        converter_->add_topic(topic_with_type.name, topic_with_type.type);
+      }
+    }
+  }
+
+  std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
+  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
+  std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_ {nullptr};
+  std::unique_ptr<Converter> converter_ {nullptr};
+};
+}  // namespace rosbag2
+
+#endif  // ROSBAG2__IMPL__SEQUENTIAL_READER_IMPL_HPP_

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -28,8 +28,9 @@ namespace rosbag2
 SequentialReader::SequentialReader(
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory)
-: storage_factory_(std::move(storage_factory)), converter_factory_(std::move(converter_factory)),
-  converter_(nullptr)
+: reader_pimpl_(std::make_unique<ReaderImpl>(
+      std::move(storage_factory),
+      std::move(converter_factory)))
 {}
 
 SequentialReader::~SequentialReader()
@@ -41,59 +42,22 @@ void
 SequentialReader::open(
   const StorageOptions & storage_options, const ConverterOptions & converter_options)
 {
-  storage_ = storage_factory_->open_read_only(storage_options.uri, storage_options.storage_id);
-  if (!storage_) {
-    throw std::runtime_error("No storage could be initialized. Abort");
-  }
-  auto topics = storage_->get_metadata().topics_with_message_count;
-  if (topics.empty()) {
-    return;
-  }
-
-  // Currently a bag file can only be played if all topics have the same serialization format.
-  auto storage_serialization_format = topics[0].topic_metadata.serialization_format;
-  for (const auto & topic : topics) {
-    if (topic.topic_metadata.serialization_format != storage_serialization_format) {
-      throw std::runtime_error("Topics with different rwm serialization format have been found. "
-              "All topics must have the same serialization format.");
-    }
-  }
-
-  if (converter_options.output_serialization_format != storage_serialization_format) {
-    converter_ = std::make_unique<Converter>(
-      storage_serialization_format,
-      converter_options.output_serialization_format,
-      converter_factory_);
-    auto topics = storage_->get_all_topics_and_types();
-    for (const auto & topic_with_type : topics) {
-      converter_->add_topic(topic_with_type.name, topic_with_type.type);
-    }
-  }
+  reader_pimpl_->open(storage_options, converter_options);
 }
 
 bool SequentialReader::has_next()
 {
-  if (storage_) {
-    return storage_->has_next();
-  }
-  throw std::runtime_error("Bag is not open. Call open() before reading.");
+  return reader_pimpl_->has_next();
 }
 
 std::shared_ptr<SerializedBagMessage> SequentialReader::read_next()
 {
-  if (storage_) {
-    auto message = storage_->read_next();
-    return converter_ ? converter_->convert(message) : message;
-  }
-  throw std::runtime_error("Bag is not open. Call open() before reading.");
+  return reader_pimpl_->read_next();
 }
 
 std::vector<TopicMetadata> SequentialReader::get_all_topics_and_types()
 {
-  if (storage_) {
-    return storage_->get_all_topics_and_types();
-  }
-  throw std::runtime_error("Bag is not open. Call open() before reading.");
+  return reader_pimpl_->get_all_topics_and_types();
 }
 
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -1,4 +1,5 @@
 // Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rosbag2/sequential_reader.hpp"
-
 #include <memory>
-#include <stdexcept>
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "rosbag2/info.hpp"
+#include "rosbag2/sequential_reader.hpp"
+
+#include "./impl/sequential_reader_impl.hpp"
 
 namespace rosbag2
 {
@@ -28,36 +28,35 @@ namespace rosbag2
 SequentialReader::SequentialReader(
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory)
-: reader_pimpl_(std::make_unique<ReaderImpl>(
+: reader_impl_(std::make_unique<ReaderImpl>(
       std::move(storage_factory),
       std::move(converter_factory)))
 {}
 
 SequentialReader::~SequentialReader()
 {
-  storage_.reset();  // Necessary to ensure that the storage is destroyed before the factory
+  reader_impl_->reset();
 }
 
-void
-SequentialReader::open(
+void SequentialReader::open(
   const StorageOptions & storage_options, const ConverterOptions & converter_options)
 {
-  reader_pimpl_->open(storage_options, converter_options);
+  reader_impl_->open(storage_options, converter_options);
 }
 
 bool SequentialReader::has_next()
 {
-  return reader_pimpl_->has_next();
+  return reader_impl_->has_next();
 }
 
 std::shared_ptr<SerializedBagMessage> SequentialReader::read_next()
 {
-  return reader_pimpl_->read_next();
+  return reader_impl_->read_next();
 }
 
 std::vector<TopicMetadata> SequentialReader::get_all_topics_and_types()
 {
-  return reader_pimpl_->get_all_topics_and_types();
+  return reader_impl_->get_all_topics_and_types();
 }
 
 }  // namespace rosbag2


### PR DESCRIPTION
## Changes
* Refactored implementation of `SequentialReader` into `src/rosbag2/impl/sequential_reader_impl.hpp`
* Exposed `SequentialReader` interface through `sequential_reader.hpp` only.

## Issue
 https://github.com/ros-security/aws-roadmap/issues/97